### PR TITLE
Update slideover.blade.php

### DIFF
--- a/demo/components.html
+++ b/demo/components.html
@@ -299,7 +299,7 @@
                     <div>
                         <label class="inline-flex items-center justify-center transition font-medium text-base rounded min-h-12 py-1.5 px-5 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer gap-x-1.5 bg-primary text-primary-text border-b border-b-black/20 hover:bg-opacity-80" for="default-slideover">
     Open Slideover
-</label>                        <div >
+</label>                        <div class="relative z-slideover">
     <input id="close-default-slideover" class="hidden" type="reset">
             <input  id="default-slideover" class="peer hidden prevent-scroll" type="checkbox">
         <label
@@ -335,7 +335,7 @@
                     <div>
                         <label class="inline-flex items-center justify-center transition font-medium text-base rounded min-h-12 py-1.5 px-5 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer gap-x-1.5 bg-secondary text-secondary-text border-b border-b-black/20 hover:bg-opacity-80" for="right-slideover">
     Open Right Slideover
-</label>                        <div >
+</label>                        <div class="relative z-slideover">
     <input id="close-right-slideover" class="hidden" type="reset">
             <input  id="right-slideover" class="peer hidden prevent-scroll" type="checkbox">
         <label
@@ -370,7 +370,7 @@
                     <div>
                         <label class="inline-flex items-center justify-center transition font-medium text-base rounded min-h-12 py-1.5 px-5 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer gap-x-1.5 bg-transparent border text-default hover:border-emphasis lg:hidden" for="mobile-slideover">
     Open Mobile Slideover
-</label>                        <div >
+</label>                        <div class="relative z-slideover">
     <input id="close-mobile-slideover" class="hidden" type="reset">
             <input  id="mobile-slideover" class="peer hidden prevent-scroll" type="checkbox">
         <label

--- a/resources/views/components/slideover/slideover.blade.php
+++ b/resources/views/components/slideover/slideover.blade.php
@@ -74,7 +74,7 @@ Nested slideovers:
     $closeId = $isInForm ? 'close-' . $id : $id;
 @endphp
 
-<x-rapidez::tag :is="$tag">
+<x-rapidez::tag :is="$tag" class="relative z-slideover">
     <input id="{{ 'close-' . $id }}" class="hidden" type="reset">
     @if (!$hasParent)
         <input @checked($open) id="{{ $id }}" class="peer hidden prevent-scroll" type="checkbox">


### PR DESCRIPTION
Instead of wrapping the div around the slideover the highest parent of the slideover should have an z-slideover.
https://github.com/rapidez/core/pull/742/files

You can see why it is needed when you open the filters on mobile. https://demo.rapidez.io/women/tops-women/jackets-women.html