### PR TITLE
Improved checkbox & radio accessibility by showing which is selected

### DIFF
--- a/demo/components.html
+++ b/demo/components.html
@@ -251,32 +251,32 @@
                 </div>
                 <div class="flex flex-col gap-y-8 lg:gap-y-14">
                     <div class="flex flex-col gap-y-4">
-                        <input type="checkbox" class="cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted" />
+                        <input type="checkbox" class="cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted" />
                         <label class="inline-flex text-neutral text-sm cursor-pointer has-[:required]:after:content-['*']">
-    <input type="checkbox" class="cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" />
+    <input type="checkbox" class="cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" />
     Checkbox
 </label>
                         <label class="inline-flex text-neutral text-sm cursor-pointer has-[:required]:after:content-['*']">
-    <input type="checkbox" class="cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" required="required" />
+    <input type="checkbox" class="cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" required="required" />
     Checkbox
 </label>
                         <label class="inline-flex text-neutral text-sm cursor-pointer has-[:required]:after:content-['*']">
-    <input type="checkbox" class="cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" disabled="disabled" />
+    <input type="checkbox" class="cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" disabled="disabled" />
     Checkbox
 </label>
                     </div>
                     <div class="flex flex-col gap-y-4">
-                        <input type="radio" class="cursor-pointer border border-default size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted" />
+                        <input type="radio" class="cursor-pointer border border-default size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted" />
                         <label class="inline-flex text text-sm cursor-pointer has-[:required]:after:content-['*']">
-    <input type="radio" class="cursor-pointer border border-default size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" />
+    <input type="radio" class="cursor-pointer border border-default size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" />
     Radio
 </label>
                         <label class="inline-flex text text-sm cursor-pointer has-[:required]:after:content-['*']">
-    <input type="radio" class="cursor-pointer border border-default size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" required="required" />
+    <input type="radio" class="cursor-pointer border border-default size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" required="required" />
     Radio
 </label>
                         <label class="inline-flex text text-sm cursor-pointer has-[:required]:after:content-['*']">
-    <input type="radio" class="cursor-pointer border border-default size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" disabled="disabled" />
+    <input type="radio" class="cursor-pointer border border-default size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted mr-2.5" disabled="disabled" />
     Radio
 </label>
                     </div>

--- a/resources/views/components/input/checkbox/base.blade.php
+++ b/resources/views/components/input/checkbox/base.blade.php
@@ -6,4 +6,4 @@ Examples:
 <x-rapidez::input.checkbox.base />
 ```
 --}}
-<input type="checkbox" {{ $attributes->twMerge('cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted') }} />
+<input type="checkbox" {{ $attributes->twMerge('cursor-pointer border border-default rounded-md size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted') }} />

--- a/resources/views/components/input/radio/base.blade.php
+++ b/resources/views/components/input/radio/base.blade.php
@@ -6,4 +6,4 @@ Examples:
 <x-rapidez::input.radio.base />
 ```
 --}}
-<input type="radio" {{ $attributes->twMerge('cursor-pointer border border-default size-5 text focus:outline-none focus:ring-0 focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted') }} />
+<input type="radio" {{ $attributes->twMerge('cursor-pointer border border-default size-5 text focus:outline-none focus:ring-emphasis focus:ring-offset-0 disabled:cursor-not-allowed disabled:bg-muted disabled:border-muted') }} />


### PR DESCRIPTION
This pr improves accessibility for users requiring keyboard controls to navigate sites.
Before a focused element was not visible to the user
![image](https://github.com/user-attachments/assets/18ea2e9d-1acd-4482-af44-3af3971061e7)
As you can see it is impossible to guess which checkbox is currently selected by the keyboard.

This change adds the ring with the emphasis color so it fits the theme.
![image](https://github.com/user-attachments/assets/31da5dca-04de-4280-ad55-0e4f207191f2)
