### PR TITLE
Fix attributes merge mobile accordion content slot

### DIFF
--- a/resources/views/components/accordion/mobile.blade.php
+++ b/resources/views/components/accordion/mobile.blade.php
@@ -18,7 +18,7 @@ This mobile version only collapses on mobile, on desktop it's always open.
     <x-slot:label :attributes="$label->attributes->twMerge('md:cursor-auto')">
         {{ $label }}
     </x-slot:label>
-    <x-slot:content>
+    <x-slot:content :attributes="$content->attributes->twMerge('pb-5')">
         {{ $content }}
     </x-slot:content>
 </x-rapidez::accordion>


### PR DESCRIPTION
When using the `<x-rapidez::accordion.mobile>` and we use the `<x-slot:content>` inside it we have default padding on it. The problem here is if you don't want the padding or you want to add some extra classes here it was not possible because we didn't merged any classes. 

**With this fix this will work** 

```
<x-slot:content class="text-white pb-0">
    {!! $footer_content->content !!}
</x-slot:content>
```
