### PR TITLE
Mobile accordion Firefox workaround

### DIFF
--- a/demo/components.html
+++ b/demo/components.html
@@ -52,9 +52,9 @@
     }
 }
 
-@supports (-moz-appearance:none) {
-    .firefox-only {
-        @apply md:pb-5 md:px-3 md:!block;
+@supports selector(::details-content) {
+    .details-content-unsupported-only {
+        @apply md:pb-5 md:px-3 md:!hidden;
     }
 }
         </style>
@@ -612,7 +612,7 @@
         Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
     </div>
 </details>
-<div class="hidden firefox-only">
+<div class="max-md:hidden md:block details-content-unsupported-only">
     Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
 </div>
                 </div>
@@ -629,7 +629,7 @@
         Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
     </div>
 </details>
-<div class="hidden firefox-only">
+<div class="max-md:hidden md:block details-content-unsupported-only">
     Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
 </div>
                 </div>

--- a/resources/css/components/detail-summary.css
+++ b/resources/css/components/detail-summary.css
@@ -38,3 +38,9 @@
         height: auto;
     }
 }
+
+@supports (-moz-appearance:none) {
+    .firefox-only {
+        @apply md:pb-5 md:px-3 md:!block;
+    }
+}

--- a/resources/css/components/detail-summary.css
+++ b/resources/css/components/detail-summary.css
@@ -39,8 +39,8 @@
     }
 }
 
-@supports (-moz-appearance:none) {
-    .firefox-only {
-        @apply md:pb-5 md:px-3 md:!block;
+@supports selector(::details-content) {
+    .details-content-unsupported-only {
+        @apply md:pb-5 md:px-3 md:!hidden;
     }
 }

--- a/resources/views/components-preview.blade.php
+++ b/resources/views/components-preview.blade.php
@@ -403,18 +403,22 @@
                         This is only an accordion on mobile devices. On desktop, it's always open.
                     </div>
                 </div>
-                <x-rapidez::accordion.mobile class="rounded border px-3" :icon="false">
-                    <x-slot:label class="font-bold">Question 1</x-slot:label>
-                    <x-slot:content>
-                        Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
-                    </x-slot:content>
-                </x-rapidez::accordion.mobile>
-                <x-rapidez::accordion.mobile class="rounded border px-3" :icon="false">
-                    <x-slot:label class="font-bold">Question 2</x-slot:label>
-                    <x-slot:content>
-                        Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
-                    </x-slot:content>
-                </x-rapidez::accordion.mobile>
+                <div class="flex flex-col rounded md:border">
+                    <x-rapidez::accordion.mobile class="rounded max-md:border px-3" :icon="false">
+                        <x-slot:label class="font-bold">Question 1</x-slot:label>
+                        <x-slot:content>
+                            Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+                        </x-slot:content>
+                    </x-rapidez::accordion.mobile>
+                </div>
+                <div class="flex flex-col rounded md:border">
+                    <x-rapidez::accordion.mobile class="rounded max-md:border px-3" :icon="false">
+                        <x-slot:label class="font-bold">Question 2</x-slot:label>
+                        <x-slot:content>
+                            Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+                        </x-slot:content>
+                    </x-rapidez::accordion.mobile>
+                </div>
             </div>
 
             <h2 class="text-2xl font-bold mt-5">Read more component</h2>

--- a/resources/views/components/accordion/mobile.blade.php
+++ b/resources/views/components/accordion/mobile.blade.php
@@ -12,6 +12,11 @@ This mobile version only collapses on mobile, on desktop it's always open.
     </x-slot:content>
 </x-rapidez::accordion.mobile>
 ```
+
+Currently, the pseudo-selector ::details-content is not supported in Firefox. We use this pseudo-selector for the mobile accordion variant.
+As a result, the section remains closed on mobile and is intended to be open on desktop using the CSS defined in resources/css/components/detail-summary.css.
+However, because Firefox doesn’t support this pseudo-selector, the section will also remain closed on desktop in Firefox.
+To address this, the div below will only be visible in Firefox so that content appears correctly on desktop. On mobile, nothing will change.
 --}}
 
 <x-rapidez::accordion :attributes="$attributes->twMerge('md:details-content:[content-visibility:visible] md:details-content:h-auto')">

--- a/resources/views/components/accordion/mobile.blade.php
+++ b/resources/views/components/accordion/mobile.blade.php
@@ -27,6 +27,6 @@ To address this, the div below will only be visible in Firefox so that content a
         {{ $content }}
     </x-slot:content>
 </x-rapidez::accordion>
-<div class="hidden firefox-only">
+<div class="max-md:hidden md:block details-content-unsupported-only">
     {{ $content }}
 </div>

--- a/resources/views/components/accordion/mobile.blade.php
+++ b/resources/views/components/accordion/mobile.blade.php
@@ -15,10 +15,13 @@ This mobile version only collapses on mobile, on desktop it's always open.
 --}}
 
 <x-rapidez::accordion :attributes="$attributes->twMerge('md:details-content:[content-visibility:visible] md:details-content:h-auto')">
-    <x-slot:label :attributes="$label->attributes->twMerge('md:cursor-auto')">
+    <x-slot:label :attributes="$label->attributes->twMerge('md:cursor-auto md:pointer-events-none')">
         {{ $label }}
     </x-slot:label>
     <x-slot:content :attributes="$content->attributes->twMerge('pb-5')">
         {{ $content }}
     </x-slot:content>
 </x-rapidez::accordion>
+<div class="hidden firefox-only">
+    {{ $content }}
+</div>


### PR DESCRIPTION
In Firefox the pseudo-selector `::details-content` is not supported yet, ref: https://caniuse.com/?search=%3A%3Adetails-content.

For the mobile accordion variant we use `md:details-content:[content-visibility:visible] md:details-content:h-auto` and in the css file: 
```
@media (min-width: 768px) {
    .md\:details-content\:\[content-visibility\:visible\]::details-content {
        content-visibility: visible !important;
    }

    .md\:details-content\:h-auto::details-content {
        height: auto;
    }
}
```
So we use the `::details-content` to show the content on desktop that is in the mobile accordion.

**This is how it looks on Chrome: (https://rapidez.github.io/blade-components/demo/components.html)** 
<img width="1533" height="217" alt="Scherm­afbeelding 2025-07-29 om 14 20 34" src="https://github.com/user-attachments/assets/26bd8116-1e7a-4dfe-9918-cf03849b6cd6" />

**But this is how it looks on FireFox: (https://rapidez.github.io/blade-components/demo/components.html)**
<img width="1528" height="102" alt="Scherm­afbeelding 2025-07-29 om 14 21 11" src="https://github.com/user-attachments/assets/8478ba90-d6f1-4f92-822e-46b2d10642b8" />
Because the `::details-content` is not supported the content will not shown on desktop. 

By adding a `<div>` below the accordion: 
```
<div class="hidden firefox-only">
    {{ $content }}
</div>
```
The content will be rendered outside the `<details>`. 
With the css we make sure it will only show on FireFox by using the `@supports (-moz-appearance:none)` 
```
@supports (-moz-appearance:none) {
    .firefox-only {
        @apply md:pb-5 md:px-3 md:!block;
    }
}
```
**Result on FireFox now:**
<img width="1550" height="246" alt="Scherm­afbeelding 2025-07-29 om 14 27 40" src="https://github.com/user-attachments/assets/85741c10-cde8-447c-8df4-683290c35119" />

_Nothing will change on mobile this will still keep working on all browsers as it did before_

I discussed the the solution with @Jade-GG as well. We could also do this with JavaScript adding the "open" attribute on the `<details>` but that solution is not preferred. 