### PR TITLE
Firefox - Work around 2

### DIFF
--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f3c691d35"
+        id="accordion-6895f3dc85548"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f3c691d35"
+        for="accordion-6895f3dc85548"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f3c695098"
+        id="accordion-6895f3dc88808"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f3c695098"
+        for="accordion-6895f3dc88808"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f45c8dea9"
+        id="accordion-6895f470edf66"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f45c8dea9"
+        for="accordion-6895f470edf66"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f45c9137e"
+        id="accordion-6895f470f1211"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f45c9137e"
+        for="accordion-6895f470f1211"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2568e1e6"
+        id="accordion-6895f26ee4ddb"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2568e1e6"
+        for="accordion-6895f26ee4ddb"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f256915a9"
+        id="accordion-6895f26ee8197"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f256915a9"
+        for="accordion-6895f26ee8197"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2142109f"
+        id="accordion-6895f2269f30a"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2142109f"
+        for="accordion-6895f2269f30a"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f21424680"
+        id="accordion-6895f226a275b"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f21424680"
+        for="accordion-6895f226a275b"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f62f36cf0"
+        id="accordion-6895f64826f34"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f62f36cf0"
+        for="accordion-6895f64826f34"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f62f3a1c3"
+        id="accordion-6895f6482a250"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f62f3a1c3"
+        for="accordion-6895f6482a250"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5b85fdd1"
+        id="accordion-6895f5cf2c904"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5b85fdd1"
+        for="accordion-6895f5cf2c904"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5b863027"
+        id="accordion-6895f5cf2fd61"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5b863027"
+        for="accordion-6895f5cf2fd61"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5a4da4ce"
+        id="accordion-6895f5b85fdd1"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5a4da4ce"
+        for="accordion-6895f5b85fdd1"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5a4dd788"
+        id="accordion-6895f5b863027"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5a4dd788"
+        for="accordion-6895f5b863027"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2269f30a"
+        id="accordion-6895f23f2b432"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2269f30a"
+        for="accordion-6895f23f2b432"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f226a275b"
+        id="accordion-6895f23f2e95e"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f226a275b"
+        for="accordion-6895f23f2e95e"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f1ac6b418"
+        id="accordion-6895f1c4386df"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f1ac6b418"
+        for="accordion-6895f1c4386df"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f1ac6e7fd"
+        id="accordion-6895f1c43ba8f"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f1ac6e7fd"
+        for="accordion-6895f1c43ba8f"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f3dc85548"
+        id="accordion-6895f3f277067"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f3dc85548"
+        for="accordion-6895f3f277067"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f3dc88808"
+        id="accordion-6895f3f27a31e"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f3dc88808"
+        for="accordion-6895f3f27a31e"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4c245c6c"
+        id="accordion-6895f4daadb3b"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4c245c6c"
+        for="accordion-6895f4daadb3b"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4c248feb"
+        id="accordion-6895f4dab0f3d"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4c248feb"
+        for="accordion-6895f4dab0f3d"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f26ee4ddb"
+        id="accordion-6895f2890870f"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f26ee4ddb"
+        for="accordion-6895f2890870f"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f26ee8197"
+        id="accordion-6895f2890be10"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f26ee8197"
+        for="accordion-6895f2890be10"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f64826f34"
+        id="accordion-6895f6611163c"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f64826f34"
+        for="accordion-6895f6611163c"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f6482a250"
+        id="accordion-6895f66114aad"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f6482a250"
+        for="accordion-6895f66114aad"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2b029ad9"
+        id="accordion-6895f2c6440ba"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2b029ad9"
+        for="accordion-6895f2c6440ba"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2b02cf94"
+        id="accordion-6895f2c6473d6"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2b02cf94"
+        for="accordion-6895f2c6473d6"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f17f0c9bc"
+        id="accordion-6895f1979fea3"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f17f0c9bc"
+        for="accordion-6895f1979fea3"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f17f0fd8f"
+        id="accordion-6895f197a3260"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f17f0fd8f"
+        for="accordion-6895f197a3260"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4097fe91"
+        id="accordion-6895f42289948"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4097fe91"
+        for="accordion-6895f42289948"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f40983260"
+        id="accordion-6895f4228cd8b"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f40983260"
+        for="accordion-6895f4228cd8b"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f1979fea3"
+        id="accordion-6895f1ac6b418"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f1979fea3"
+        for="accordion-6895f1ac6b418"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f197a3260"
+        id="accordion-6895f1ac6e7fd"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f197a3260"
+        for="accordion-6895f1ac6e7fd"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f42289948"
+        id="accordion-6895f436a2936"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f42289948"
+        for="accordion-6895f436a2936"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4228cd8b"
+        id="accordion-6895f436a5ef7"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4228cd8b"
+        for="accordion-6895f436a5ef7"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4daadb3b"
+        id="accordion-6895f4ee6691a"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4daadb3b"
+        for="accordion-6895f4ee6691a"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4dab0f3d"
+        id="accordion-6895f4ee69dc7"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4dab0f3d"
+        for="accordion-6895f4ee69dc7"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f3a7bcad9"
+        id="accordion-6895f3c691d35"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f3a7bcad9"
+        for="accordion-6895f3c691d35"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f3a7bfec5"
+        id="accordion-6895f3c695098"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f3a7bfec5"
+        for="accordion-6895f3c695098"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f3f277067"
+        id="accordion-6895f4097fe91"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f3f277067"
+        for="accordion-6895f4097fe91"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f3f27a31e"
+        id="accordion-6895f40983260"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f3f27a31e"
+        for="accordion-6895f40983260"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5f7bd5a4"
+        id="accordion-6895f6117b828"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5f7bd5a4"
+        for="accordion-6895f6117b828"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5f7c0999"
+        id="accordion-6895f6117ec35"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5f7c0999"
+        for="accordion-6895f6117ec35"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f58ee9550"
+        id="accordion-6895f5a4da4ce"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f58ee9550"
+        for="accordion-6895f5a4da4ce"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f58eec9ce"
+        id="accordion-6895f5a4dd788"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f58eec9ce"
+        for="accordion-6895f5a4dd788"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f29d7c2ac"
+        id="accordion-6895f2b029ad9"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f29d7c2ac"
+        for="accordion-6895f2b029ad9"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f29d7f9ec"
+        id="accordion-6895f2b02cf94"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f29d7f9ec"
+        for="accordion-6895f2b02cf94"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4af96216"
+        id="accordion-6895f4c245c6c"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4af96216"
+        for="accordion-6895f4c245c6c"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4af99998"
+        id="accordion-6895f4c248feb"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4af99998"
+        for="accordion-6895f4c248feb"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2dd9bf72"
+        id="accordion-6895f2f589491"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2dd9bf72"
+        for="accordion-6895f2f589491"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2dd9f3ce"
+        id="accordion-6895f2f58c764"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2dd9f3ce"
+        for="accordion-6895f2f58c764"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f369dd59e"
+        id="accordion-6895f37fd6d77"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f369dd59e"
+        for="accordion-6895f37fd6d77"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f369e0923"
+        id="accordion-6895f37fda29d"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f369e0923"
+        for="accordion-6895f37fda29d"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f531e2235"
+        id="accordion-6895f54a7db09"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f531e2235"
+        for="accordion-6895f54a7db09"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f531e561d"
+        id="accordion-6895f54a80cdb"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f531e561d"
+        for="accordion-6895f54a80cdb"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -593,31 +593,43 @@
                         This is only an accordion on mobile devices. On desktop, it's always open.
                     </div>
                 </div>
-                <details
-    class="group/details details-content:h-0 details-content:overflow-clip details-content:transition-[height,content-visibility] details-content:transition-discrete details-content:duration-200 open:details-content:h-auto md:details-content:[content-visibility:visible] md:details-content:h-auto rounded border px-3"
->
-    <summary class="flex items-center py-3.5 cursor-pointer list-none md:cursor-auto font-bold">
+                <div class="flex flex-col group rounded border p-3">
+    <input
+        id="accordion-6895f17f0c9bc"
+        name=""
+        type="checkbox"
+                class="peer hidden"
+    />
+    <label
+        for="accordion-6895f17f0c9bc"
+        class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
+            >
         Question 1
-
-            </summary>
-
-    <div class="pb-5">
-        Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+    </label>
+    <div class="grid peer-checked:grid-rows-[1fr] grid-rows-[0fr] transition-all md:grid-rows-[1fr]">
+        <div class="overflow-hidden">
+            Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+        </div>
     </div>
-</details>
-                <details
-    class="group/details details-content:h-0 details-content:overflow-clip details-content:transition-[height,content-visibility] details-content:transition-discrete details-content:duration-200 open:details-content:h-auto md:details-content:[content-visibility:visible] md:details-content:h-auto rounded border px-3"
->
-    <summary class="flex items-center py-3.5 cursor-pointer list-none md:cursor-auto font-bold">
+</div>                <div class="flex flex-col group rounded border p-3">
+    <input
+        id="accordion-6895f17f0fd8f"
+        name=""
+        type="checkbox"
+                class="peer hidden"
+    />
+    <label
+        for="accordion-6895f17f0fd8f"
+        class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
+            >
         Question 2
-
-            </summary>
-
-    <div class="pb-5">
-        Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+    </label>
+    <div class="grid peer-checked:grid-rows-[1fr] grid-rows-[0fr] transition-all md:grid-rows-[1fr]">
+        <div class="overflow-hidden">
+            Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+        </div>
     </div>
-</details>
-            </div>
+</div>            </div>
 
             <h2 class="text-2xl font-bold mt-5">Read more component</h2>
             <div class="grid grid-cols-1 gap-5 items-start lg:grid-cols-3">

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f56084950"
+        id="accordion-6895f5794c37b"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f56084950"
+        for="accordion-6895f5794c37b"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f56087d30"
+        id="accordion-6895f5794f7af"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f56087d30"
+        for="accordion-6895f5794f7af"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5cf2c904"
+        id="accordion-6895f5e601b1f"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5cf2c904"
+        for="accordion-6895f5e601b1f"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5cf2fd61"
+        id="accordion-6895f5e6053c2"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5cf2fd61"
+        for="accordion-6895f5e6053c2"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f50753c16"
+        id="accordion-6895f51bdd499"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f50753c16"
+        for="accordion-6895f51bdd499"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f50756fab"
+        id="accordion-6895f51be0754"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f50756fab"
+        for="accordion-6895f51be0754"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2890870f"
+        id="accordion-6895f29d7c2ac"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2890870f"
+        for="accordion-6895f29d7c2ac"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2890be10"
+        id="accordion-6895f29d7f9ec"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2890be10"
+        for="accordion-6895f29d7f9ec"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f30bdb190"
+        id="accordion-6895f32a9acde"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f30bdb190"
+        for="accordion-6895f32a9acde"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f30bde573"
+        id="accordion-6895f32a9df36"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f30bde573"
+        for="accordion-6895f32a9df36"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f1e144ed8"
+        id="accordion-6895f1f8cdd1c"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f1e144ed8"
+        for="accordion-6895f1f8cdd1c"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f1e1483a2"
+        id="accordion-6895f1f8d11a9"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f1e1483a2"
+        for="accordion-6895f1f8d11a9"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2f589491"
+        id="accordion-6895f30bdb190"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2f589491"
+        for="accordion-6895f30bdb190"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2f58c764"
+        id="accordion-6895f30bde573"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2f58c764"
+        for="accordion-6895f30bde573"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f1c4386df"
+        id="accordion-6895f1e144ed8"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f1c4386df"
+        for="accordion-6895f1e144ed8"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f1c43ba8f"
+        id="accordion-6895f1e1483a2"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f1c43ba8f"
+        for="accordion-6895f1e1483a2"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f6117b828"
+        id="accordion-6895f62f36cf0"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f6117b828"
+        for="accordion-6895f62f36cf0"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f6117ec35"
+        id="accordion-6895f62f3a1c3"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f6117ec35"
+        for="accordion-6895f62f3a1c3"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f33f8af0f"
+        id="accordion-6895f354e88ed"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f33f8af0f"
+        for="accordion-6895f354e88ed"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f33f8e401"
+        id="accordion-6895f354ebf42"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f33f8e401"
+        for="accordion-6895f354ebf42"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f436a2936"
+        id="accordion-6895f44a6e637"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f436a2936"
+        for="accordion-6895f44a6e637"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f436a5ef7"
+        id="accordion-6895f44a719df"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f436a5ef7"
+        for="accordion-6895f44a719df"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4ee6691a"
+        id="accordion-6895f50753c16"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4ee6691a"
+        for="accordion-6895f50753c16"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4ee69dc7"
+        id="accordion-6895f50756fab"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4ee69dc7"
+        for="accordion-6895f50756fab"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f4839ef3b"
+        id="accordion-6895f49a5ee87"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f4839ef3b"
+        for="accordion-6895f49a5ee87"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f483a22de"
+        id="accordion-6895f49a62387"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f483a22de"
+        for="accordion-6895f49a62387"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f44a6e637"
+        id="accordion-6895f45c8dea9"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f44a6e637"
+        for="accordion-6895f45c8dea9"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f44a719df"
+        id="accordion-6895f45c9137e"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f44a719df"
+        for="accordion-6895f45c9137e"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f6611163c"
+        id="accordion-6895f67aecb10"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f6611163c"
+        for="accordion-6895f67aecb10"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f66114aad"
+        id="accordion-6895f67aefea5"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f66114aad"
+        for="accordion-6895f67aefea5"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f354e88ed"
+        id="accordion-6895f369dd59e"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f354e88ed"
+        for="accordion-6895f369dd59e"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f354ebf42"
+        id="accordion-6895f369e0923"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f354ebf42"
+        for="accordion-6895f369e0923"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f32a9acde"
+        id="accordion-6895f33f8af0f"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f32a9acde"
+        for="accordion-6895f33f8af0f"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f32a9df36"
+        id="accordion-6895f33f8e401"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f32a9df36"
+        for="accordion-6895f33f8e401"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5794c37b"
+        id="accordion-6895f58ee9550"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5794c37b"
+        for="accordion-6895f58ee9550"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5794f7af"
+        id="accordion-6895f58eec9ce"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5794f7af"
+        for="accordion-6895f58eec9ce"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f37fd6d77"
+        id="accordion-6895f393dd855"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f37fd6d77"
+        for="accordion-6895f393dd855"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f37fda29d"
+        id="accordion-6895f393e11c1"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f37fda29d"
+        for="accordion-6895f393e11c1"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f393dd855"
+        id="accordion-6895f3a7bcad9"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f393dd855"
+        for="accordion-6895f3a7bcad9"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f393e11c1"
+        id="accordion-6895f3a7bfec5"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f393e11c1"
+        for="accordion-6895f3a7bfec5"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f23f2b432"
+        id="accordion-6895f2568e1e6"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f23f2b432"
+        for="accordion-6895f2568e1e6"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f23f2e95e"
+        id="accordion-6895f256915a9"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f23f2e95e"
+        for="accordion-6895f256915a9"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f49a5ee87"
+        id="accordion-6895f4af96216"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f49a5ee87"
+        for="accordion-6895f4af96216"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f49a62387"
+        id="accordion-6895f4af99998"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f49a62387"
+        for="accordion-6895f4af99998"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f1f8cdd1c"
+        id="accordion-6895f2142109f"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f1f8cdd1c"
+        for="accordion-6895f2142109f"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f1f8d11a9"
+        id="accordion-6895f21424680"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f1f8d11a9"
+        for="accordion-6895f21424680"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f54a7db09"
+        id="accordion-6895f56084950"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f54a7db09"
+        for="accordion-6895f56084950"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f54a80cdb"
+        id="accordion-6895f56087d30"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f54a80cdb"
+        for="accordion-6895f56087d30"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f51bdd499"
+        id="accordion-6895f531e2235"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f51bdd499"
+        for="accordion-6895f531e2235"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f51be0754"
+        id="accordion-6895f531e561d"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f51be0754"
+        for="accordion-6895f531e561d"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2c6440ba"
+        id="accordion-6895f2dd9bf72"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2c6440ba"
+        for="accordion-6895f2dd9bf72"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f2c6473d6"
+        id="accordion-6895f2dd9f3ce"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f2c6473d6"
+        for="accordion-6895f2dd9f3ce"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5e601b1f"
+        id="accordion-6895f5f7bd5a4"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5e601b1f"
+        for="accordion-6895f5f7bd5a4"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f5e6053c2"
+        id="accordion-6895f5f7c0999"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f5e6053c2"
+        for="accordion-6895f5f7c0999"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/demo/components.html
+++ b/demo/components.html
@@ -595,13 +595,13 @@
                 </div>
                 <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f470edf66"
+        id="accordion-6895f4839ef3b"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f470edf66"
+        for="accordion-6895f4839ef3b"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 1
@@ -613,13 +613,13 @@
     </div>
 </div>                <div class="flex flex-col group rounded border p-3">
     <input
-        id="accordion-6895f470f1211"
+        id="accordion-6895f483a22de"
         name=""
         type="checkbox"
                 class="peer hidden"
     />
     <label
-        for="accordion-6895f470f1211"
+        for="accordion-6895f483a22de"
         class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
             >
         Question 2

--- a/resources/views/components-preview.blade.php
+++ b/resources/views/components-preview.blade.php
@@ -403,13 +403,13 @@
                         This is only an accordion on mobile devices. On desktop, it's always open.
                     </div>
                 </div>
-                <x-rapidez::accordion.mobile class="rounded border px-3" :icon="false">
+                <x-rapidez::accordion.mobile class="rounded border p-3" :icon="false">
                     <x-slot:label class="font-bold">Question 1</x-slot:label>
                     <x-slot:content>
                         Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
                     </x-slot:content>
                 </x-rapidez::accordion.mobile>
-                <x-rapidez::accordion.mobile class="rounded border px-3" :icon="false">
+                <x-rapidez::accordion.mobile class="rounded border p-3" :icon="false">
                     <x-slot:label class="font-bold">Question 2</x-slot:label>
                     <x-slot:content>
                         Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.

--- a/resources/views/components/accordion/mobile.blade.php
+++ b/resources/views/components/accordion/mobile.blade.php
@@ -12,13 +12,37 @@ This mobile version only collapses on mobile, on desktop it's always open.
     </x-slot:content>
 </x-rapidez::accordion.mobile>
 ```
+
+Currently, the pseudo-selector ::details-content is not supported in Firefox. We use this pseudo-selector for the mobile accordion variant.
+As a result, the section remains closed on mobile and is intended to be open on desktop using the CSS defined in resources/css/components/detail-summary.css.
+However, because Firefox doesn’t support this pseudo-selector, the section will also remain closed on desktop in Firefox.
+To address this, we have changed the mobile accordion and use an input and label to toggle the content on mobile and keep it always open on desktop.
+
 --}}
 
-<x-rapidez::accordion :attributes="$attributes->twMerge('md:details-content:[content-visibility:visible] md:details-content:h-auto')">
-    <x-slot:label :attributes="$label->attributes->twMerge('md:cursor-auto')">
+@props(['id' => uniqid('accordion-'), 'type' => 'checkbox', 'name' => '', 'opened' => false])
+@slots(['label', 'content'])
+
+<div {{ $attributes->twMerge('flex flex-col group') }}>
+    <input
+        id="{{ $id }}"
+        name="{{ $name }}"
+        type="{{ $type }}"
+        @checked($opened)
+        class="peer hidden"
+    />
+    <label
+        for="{{ $id }}"
+        {{ $label->attributes->twMerge('flex items-center gap-2 justify-between cursor-pointer md:cursor-auto') }}
+        @if ($type === 'radio')
+            onclick="event.preventDefault(); document.getElementById('{{ $id }}').checked = !document.getElementById('{{ $id }}').checked;"
+        @endif
+    >
         {{ $label }}
-    </x-slot:label>
-    <x-slot:content :attributes="$content->attributes->twMerge('pb-5')">
-        {{ $content }}
-    </x-slot:content>
-</x-rapidez::accordion>
+    </label>
+    <div {{ $content->attributes->twMerge('grid peer-checked:grid-rows-[1fr] grid-rows-[0fr] transition-all md:grid-rows-[1fr]') }}>
+        <div class="overflow-hidden">
+            {{ $content }}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Here we have a solution: https://github.com/rapidez/blade-components/pull/30 to make the mobile accordion working on desktop as it won't show on Firefox because of the `::details-content` is not supported. The solution we used here will have an extra `div` and shows the content on browsers that doesn't support `::details-content`. This will result in a little duplicate content. 

In this pull request I changed the mobile accordion back to what it was, using the input, label "hack". So the content in the accordion will stay open on desktop. 

In my opinion I prefer the solution here https://github.com/rapidez/blade-components/pull/30 more then this one because when the browser support for `::details-content` is beter the changes we have to make are less then refactor it back from this variant. 