### PR TITLE
Firefox workaround mobile accordion

### DIFF
--- a/demo/components.html
+++ b/demo/components.html
@@ -593,31 +593,43 @@
                         This is only an accordion on mobile devices. On desktop, it's always open.
                     </div>
                 </div>
-                <details
-    class="group/details details-content:h-0 details-content:overflow-clip details-content:transition-[height,content-visibility] details-content:transition-discrete details-content:duration-200 open:details-content:h-auto md:details-content:[content-visibility:visible] md:details-content:h-auto rounded border px-3"
->
-    <summary class="flex items-center py-3.5 cursor-pointer list-none md:cursor-auto font-bold">
+                <div class="flex flex-col group rounded border p-3">
+    <input
+        id="1"
+        name=""
+        type="checkbox"
+                class="peer hidden"
+    />
+    <label
+        for="1"
+        class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
+            >
         Question 1
-
-            </summary>
-
-    <div class="pb-5">
-        Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+    </label>
+    <div class="grid peer-checked:grid-rows-[1fr] grid-rows-[0fr] transition-all md:grid-rows-[1fr]">
+        <div class="overflow-hidden">
+            Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+        </div>
     </div>
-</details>
-                <details
-    class="group/details details-content:h-0 details-content:overflow-clip details-content:transition-[height,content-visibility] details-content:transition-discrete details-content:duration-200 open:details-content:h-auto md:details-content:[content-visibility:visible] md:details-content:h-auto rounded border px-3"
->
-    <summary class="flex items-center py-3.5 cursor-pointer list-none md:cursor-auto font-bold">
+</div>                <div class="flex flex-col group rounded border p-3">
+    <input
+        id="2"
+        name=""
+        type="checkbox"
+                class="peer hidden"
+    />
+    <label
+        for="2"
+        class="flex items-center gap-2 justify-between cursor-pointer md:cursor-auto font-bold"
+            >
         Question 2
-
-            </summary>
-
-    <div class="pb-5">
-        Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+    </label>
+    <div class="grid peer-checked:grid-rows-[1fr] grid-rows-[0fr] transition-all md:grid-rows-[1fr]">
+        <div class="overflow-hidden">
+            Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
+        </div>
     </div>
-</details>
-            </div>
+</div>            </div>
 
             <h2 class="text-2xl font-bold mt-5">Read more component</h2>
             <div class="grid grid-cols-1 gap-5 items-start lg:grid-cols-3">

--- a/resources/views/components-preview.blade.php
+++ b/resources/views/components-preview.blade.php
@@ -403,13 +403,13 @@
                         This is only an accordion on mobile devices. On desktop, it's always open.
                     </div>
                 </div>
-                <x-rapidez::accordion.mobile class="rounded border px-3" :icon="false">
+                <x-rapidez::accordion.mobile id="1" class="rounded border p-3" :icon="false">
                     <x-slot:label class="font-bold">Question 1</x-slot:label>
                     <x-slot:content>
                         Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.
                     </x-slot:content>
                 </x-rapidez::accordion.mobile>
-                <x-rapidez::accordion.mobile class="rounded border px-3" :icon="false">
+                <x-rapidez::accordion.mobile id="2" class="rounded border p-3" :icon="false">
                     <x-slot:label class="font-bold">Question 2</x-slot:label>
                     <x-slot:content>
                         Lorem ipsum dolor, sit, amet consectetur adipisicing elit. Reprehenderit eum in deleniti dicta ducimus perspiciatis provident tempore. Consequuntur nemo blanditiis delectus, quasi velit illum ipsa quibusdam maiores cupiditate itaque repellendus.

--- a/resources/views/components/accordion/mobile.blade.php
+++ b/resources/views/components/accordion/mobile.blade.php
@@ -12,13 +12,37 @@ This mobile version only collapses on mobile, on desktop it's always open.
     </x-slot:content>
 </x-rapidez::accordion.mobile>
 ```
+
+Currently, the pseudo-selector ::details-content is not supported in Firefox. We use this pseudo-selector for the mobile accordion variant.
+As a result, the section remains closed on mobile and is intended to be open on desktop using the CSS defined in resources/css/components/detail-summary.css.
+However, because Firefox doesn’t support this pseudo-selector, the section will also remain closed on desktop in Firefox.
+To address this, we have changed the mobile accordion and use an input and label to toggle the content on mobile and keep it always open on desktop.
+
 --}}
 
-<x-rapidez::accordion :attributes="$attributes->twMerge('md:details-content:[content-visibility:visible] md:details-content:h-auto')">
-    <x-slot:label :attributes="$label->attributes->twMerge('md:cursor-auto')">
+@props(['id' => uniqid('accordion-'), 'type' => 'checkbox', 'name' => '', 'opened' => false])
+@slots(['label', 'content'])
+
+<div {{ $attributes->twMerge('flex flex-col group') }}>
+    <input
+        id="{{ $id }}"
+        name="{{ $name }}"
+        type="{{ $type }}"
+        @checked($opened)
+        class="peer hidden"
+    />
+    <label
+        for="{{ $id }}"
+        {{ $label->attributes->twMerge('flex items-center gap-2 justify-between cursor-pointer md:cursor-auto') }}
+        @if ($type === 'radio')
+            onclick="event.preventDefault(); document.getElementById('{{ $id }}').checked = !document.getElementById('{{ $id }}').checked;"
+        @endif
+    >
         {{ $label }}
-    </x-slot:label>
-    <x-slot:content :attributes="$content->attributes->twMerge('pb-5')">
-        {{ $content }}
-    </x-slot:content>
-</x-rapidez::accordion>
+    </label>
+    <div {{ $content->attributes->twMerge('grid peer-checked:grid-rows-[1fr] grid-rows-[0fr] transition-all md:grid-rows-[1fr]') }}>
+        <div class="overflow-hidden">
+            {{ $content }}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
Here we have a solution: https://github.com/rapidez/blade-components/pull/30 to make the mobile accordion working on desktop as it won't show on Firefox because of the ::details-content is not supported. The solution we used here will have an extra div and shows the content on browsers that doesn't support ::details-content. This will result in a little duplicate content.

In this pull request I changed the mobile accordion back to what it was, using the input, label "hack". So the content in the accordion will stay open on desktop.

In my opinion I prefer the solution here https://github.com/rapidez/blade-components/pull/30 more then this one because when the browser support for ::details-content is beter the changes we have to make are less then refactor it back from this variant.